### PR TITLE
Update dist.js

### DIFF
--- a/dist.js
+++ b/dist.js
@@ -95,5 +95,4 @@ var icsToJson = function icsToJson(icsData) {
   return array;
 };
 
-var _default = icsToJson;
-exports.default = _default;
+module.exports = icsToJson;


### PR DESCRIPTION
Using exports.default is causing a bug where the the icsToJson is not recognized as a function when it is imported and used on other codes.