### PR TITLE
Changing build destination.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A tool to convert ICS calendars to JSON",
   "main": "dist.js",
   "scripts": {
-    "build": "babel icsToJson.js -o dist.js",
+    "build": "babel icsToJson.js -o index.js",
     "test": "jest"
   },
   "keywords": [


### PR DESCRIPTION
If transpiling to `index.js` rather than `dist.js`, Node scripts can consume this package via `require`.

Signed-off-by: Jeremy Fuksa <hello@orangefla.me>